### PR TITLE
Add register for SPP

### DIFF
--- a/app/src/main/java/com/example/eventplanner/activities/RegisterActivity.java
+++ b/app/src/main/java/com/example/eventplanner/activities/RegisterActivity.java
@@ -4,8 +4,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Patterns;
+import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.RadioGroup;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -18,6 +21,12 @@ public class RegisterActivity extends AppCompatActivity {
     private TextInputEditText firstNameEditText, lastNameEditText, emailEditText, passwordEditText, confirmPasswordEditText, addressEditText, phoneEditText;
     private ImageView profileImageView;
     private Button uploadProfilePicButton, registerButton;
+    private LinearLayout eventOrganizerForm;
+    private LinearLayout serviceProviderForm;
+    private RadioGroup userTypeRadioGroup;
+
+
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -32,6 +41,9 @@ public class RegisterActivity extends AppCompatActivity {
         addressEditText = findViewById(R.id.addressEditText);
         phoneEditText = findViewById(R.id.phoneEditText);
         registerButton = findViewById(R.id.registerButton);
+        eventOrganizerForm = findViewById(R.id.eventOrganizerForm);
+        serviceProviderForm = findViewById(R.id.serviceProviderForm);
+        userTypeRadioGroup = findViewById(R.id.userTypeRadioGroup);
         uploadProfilePicButton.setOnClickListener(v -> {
             Toast.makeText(RegisterActivity.this, "Profile picture upload feature coming soon!", Toast.LENGTH_SHORT).show();
         });
@@ -41,6 +53,19 @@ public class RegisterActivity extends AppCompatActivity {
                 createUser();
                 Intent intent = new Intent(RegisterActivity.this, LoginActivity.class);
                 startActivity(intent);
+            }
+        });
+
+        userTypeRadioGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(RadioGroup group, int checkedId) {
+                if (checkedId == R.id.eventOrganizerRadioButton) {
+                    eventOrganizerForm.setVisibility(View.VISIBLE);
+                    serviceProviderForm.setVisibility(View.GONE);
+                } else if (checkedId == R.id.serviceProviderRadioButton) {
+                    eventOrganizerForm.setVisibility(View.GONE);
+                    serviceProviderForm.setVisibility(View.VISIBLE);
+                }
             }
         });
     }

--- a/app/src/main/res/layout/activity_registers.xml
+++ b/app/src/main/res/layout/activity_registers.xml
@@ -10,118 +10,229 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <!-- Profile Picture -->
-        <ImageView
-            android:id="@+id/profileImageView"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
-            android:layout_gravity="center"
-            android:contentDescription="Profile Picture"
-            />
-
-        <Button
-            android:id="@+id/uploadProfilePicButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:text="Upload Profile Picture"
-            app:cornerRadius="8dp"
-            style="@style/Widget.MaterialComponents.Button.TextButton" />
-
-        <!-- First Name -->
-        <com.google.android.material.textfield.TextInputLayout
+        <!-- Radio Buttons to Choose User Type -->
+        <RadioGroup
+            android:id="@+id/userTypeRadioGroup"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="First Name">
+            android:orientation="horizontal"
+            android:layout_marginBottom="16dp">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/firstNameEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </com.google.android.material.textfield.TextInputLayout>
+            <RadioButton
+                android:id="@+id/eventOrganizerRadioButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Event Organizer"
+                android:checked="true" />
 
-        <!-- Last Name -->
-        <com.google.android.material.textfield.TextInputLayout
+            <RadioButton
+                android:id="@+id/serviceProviderRadioButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Service/Product Provider" />
+        </RadioGroup>
+
+        <!-- Event Organizer Form -->
+        <LinearLayout
+            android:id="@+id/eventOrganizerForm"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Last Name">
+            android:orientation="vertical">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/lastNameEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </com.google.android.material.textfield.TextInputLayout>
+            <!-- Include Event Organizer Fields Here -->
+            <!-- Profile Picture -->
+            <ImageView
+                android:id="@+id/profileImageView"
+                android:layout_width="100dp"
+                android:layout_height="100dp"
+                android:layout_gravity="center"
+                android:contentDescription="Profile Picture" />
 
-        <!-- Email Address -->
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Email Address"
-            app:endIconMode="clear_text">
+            <Button
+                android:id="@+id/uploadProfilePicButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="Upload Profile Picture"
+                app:cornerRadius="8dp"
+                style="@style/Widget.MaterialComponents.Button.TextButton" />
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/emailEditText"
+            <!-- First Name -->
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="textEmailAddress" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:hint="First Name">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/firstNameEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </com.google.android.material.textfield.TextInputLayout>
 
-        <!-- Password -->
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Password"
-            app:endIconMode="password_toggle">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/passwordEditText"
+            <!-- Last Name -->
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="textPassword" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:hint="Last Name">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/lastNameEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </com.google.android.material.textfield.TextInputLayout>
 
-        <!-- Confirm Password -->
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Confirm Password"
-            app:endIconMode="password_toggle">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/confirmPasswordEditText"
+            <!-- Email Address -->
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="textPassword" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <!-- Address -->
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Address">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/addressEditText"
+                android:hint="Email Address"
+                app:endIconMode="clear_text">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/emailEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textEmailAddress" />
+            </com.google.android.material.textfield.TextInputLayout>
+            <!-- Password -->
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="textPostalAddress" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:hint="Password"
+                app:endIconMode="password_toggle">
 
-        <!-- Phone Number -->
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Phone Number"
-            app:endIconMode="clear_text">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/passwordEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textPassword" />
+            </com.google.android.material.textfield.TextInputLayout>
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/phoneEditText"
+            <!-- Confirm Password -->
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="phone" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:hint="Confirm Password"
+                app:endIconMode="password_toggle">
 
-        <!-- Register Button -->
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/confirmPasswordEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textPassword" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Address -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Address">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/addressEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textPostalAddress" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Phone Number -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Phone Number"
+                app:endIconMode="clear_text">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/phoneEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="phone" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Additional Fields for Event Organizer... -->
+
+        </LinearLayout>
+
+        <!-- Service/Product Provider Form -->
+        <LinearLayout
+            android:id="@+id/serviceProviderForm"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <!-- Company Name -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Company Name">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/companyNameEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Email Address -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Email Address"
+                app:endIconMode="clear_text">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/companyEmailEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textEmailAddress" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Password -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Password"
+                app:endIconMode="password_toggle">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/companyPasswordEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textPassword" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Confirm Password -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Confirm Password"
+                app:endIconMode="password_toggle">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/companyConfirmPasswordEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textPassword" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Contact Name -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Contact Name">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/contactNameEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Company Description -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Company Description">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/companyDescriptionEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Additional Fields for Service Provider... -->
+
+        </LinearLayout>
         <Button
             android:id="@+id/registerButton"
             android:layout_width="match_parent"


### PR DESCRIPTION
This pull request adds functionality to the registration activity to support two types of users: Event Organizers and Service/Product Providers. The most important changes include adding new UI components and logic to handle user type selection and form visibility.

**UI Enhancements:**

* [`app/src/main/res/layout/activity_registers.xml`](diffhunk://#diff-469c09f9c5096ecdafd09b20be477a1e6ef23279e1cff33f78f018d09bc469b5R13-R49): Added `RadioGroup` with `RadioButton` options for selecting user type (Event Organizer or Service/Product Provider). Added separate `LinearLayout` forms for each user type with respective fields. [[1]](diffhunk://#diff-469c09f9c5096ecdafd09b20be477a1e6ef23279e1cff33f78f018d09bc469b5R13-R49) [[2]](diffhunk://#diff-469c09f9c5096ecdafd09b20be477a1e6ef23279e1cff33f78f018d09bc469b5L124-R235)

**Activity Logic Updates:**

* [`app/src/main/java/com/example/eventplanner/activities/RegisterActivity.java`](diffhunk://#diff-ddbf1a607c724683ea356716bf03d8d66506db74760b1b8be1a254d4efb6aa2aR7-R11): Imported necessary UI components and added new member variables for the user type selection and forms. [[1]](diffhunk://#diff-ddbf1a607c724683ea356716bf03d8d66506db74760b1b8be1a254d4efb6aa2aR7-R11) [[2]](diffhunk://#diff-ddbf1a607c724683ea356716bf03d8d66506db74760b1b8be1a254d4efb6aa2aR24-R29)
* [`app/src/main/java/com/example/eventplanner/activities/RegisterActivity.java`](diffhunk://#diff-ddbf1a607c724683ea356716bf03d8d66506db74760b1b8be1a254d4efb6aa2aR44-R46): Initialized the new UI components in the `onCreate` method and added a listener to handle the visibility of the forms based on user type selection. [[1]](diffhunk://#diff-ddbf1a607c724683ea356716bf03d8d66506db74760b1b8be1a254d4efb6aa2aR44-R46) [[2]](diffhunk://#diff-ddbf1a607c724683ea356716bf03d8d66506db74760b1b8be1a254d4efb6aa2aR58-R70)