### PR TITLE
Add attendance button

### DIFF
--- a/app/src/main/java/com/example/eventplanner/clients/repositories/event/EventRepository.java
+++ b/app/src/main/java/com/example/eventplanner/clients/repositories/event/EventRepository.java
@@ -126,4 +126,38 @@ public class EventRepository {
       ));
       return liveData;
    }
+   public LiveData<Boolean> isUserAttending(long eventId) {
+      MutableLiveData<Boolean> result = new MutableLiveData<>();
+      Call<Boolean> call = eventService.isUserAttending(eventId);
+
+      call.enqueue(new SimpleCallback<>(
+              response -> result.setValue(response != null && response.body() != null ? response.body() : false),
+              error -> result.setValue(false)
+      ));
+      return result;
+   }
+
+   public LiveData<Boolean> attendEvent(long eventId) {
+      MutableLiveData<Boolean> result = new MutableLiveData<>();
+      Call<Void> call = eventService.attendEvent(eventId);
+
+      call.enqueue(new SimpleCallback<>(
+              response -> result.setValue(response != null && response.isSuccessful()),
+              error -> result.setValue(false)
+      ));
+      return result;
+   }
+
+   public LiveData<Boolean> removeAttendance(long eventId) {
+      MutableLiveData<Boolean> result = new MutableLiveData<>();
+      Call<Void> call = eventService.removeAttendance(eventId);
+
+      call.enqueue(new SimpleCallback<>(
+              response -> result.setValue(response != null && response.isSuccessful()),
+              error -> result.setValue(false)
+      ));
+      return result;
+   }
+
+
 }

--- a/app/src/main/java/com/example/eventplanner/clients/services/event/EventService.java
+++ b/app/src/main/java/com/example/eventplanner/clients/services/event/EventService.java
@@ -99,4 +99,14 @@ public interface EventService {
     @Headers({"Content-Type:application/json"})
     @GET("events/max-attendances-range")
     Call<List<Integer>> getMaxAttendancesRange();
+
+    @GET("events/{id}/attend")
+    Call<Boolean> isUserAttending(@Path("id") long id);
+
+    @POST("events/{id}/attend")
+    Call<Void> attendEvent(@Path("id") long id);
+
+    @DELETE("events/{id}/attend")
+    Call<Void> removeAttendance(@Path("id") long id);
+
 }

--- a/app/src/main/java/com/example/eventplanner/fragments/event/EventDetailsFragment.java
+++ b/app/src/main/java/com/example/eventplanner/fragments/event/EventDetailsFragment.java
@@ -250,7 +250,7 @@ public class EventDetailsFragment extends Fragment {
     private void setupAttendButton() {
         // Initially disable until event is loaded
         btnAttendEvent.setEnabled(false);
-
+        if (!AuthUtils.isLoggedIn(requireContext())) return;
         // Observe attendance state when event is loaded
         viewModel.isUserAttending(eventId).observe(getViewLifecycleOwner(), attending -> {
             isAttending = Boolean.TRUE.equals(attending);

--- a/app/src/main/java/com/example/eventplanner/fragments/event/EventDetailsViewModel.java
+++ b/app/src/main/java/com/example/eventplanner/fragments/event/EventDetailsViewModel.java
@@ -23,6 +23,24 @@ public class EventDetailsViewModel extends ViewModel {
         return event;
     }
 
+    public LiveData<Boolean> isUserAttending(long eventId) {
+        MutableLiveData<Boolean> result = new MutableLiveData<>();
+        tracker.observeOnce(eventRepository.isUserAttending(eventId), result, true);
+        return result;
+    }
+
+    public LiveData<Boolean> attendEvent(long eventId) {
+        MutableLiveData<Boolean> result = new MutableLiveData<>();
+        tracker.observeOnce(eventRepository.attendEvent(eventId), result, true);
+        return result;
+    }
+
+    public LiveData<Boolean> removeAttendance(long eventId) {
+        MutableLiveData<Boolean> result = new MutableLiveData<>();
+        tracker.observeOnce(eventRepository.removeAttendance(eventId), result, true);
+        return result;
+    }
+
     @Override
     protected void onCleared() {
         super.onCleared();

--- a/app/src/main/res/layout/fragment_event_details.xml
+++ b/app/src/main/res/layout/fragment_event_details.xml
@@ -191,5 +191,12 @@
                 android:layout_gravity="center"
                 android:visibility="gone"/>
         </FrameLayout>
+        <Button
+            android:id="@+id/btn_attend_event"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Attend Event"
+            android:layout_marginTop="16dp"/>
+
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
This pull request introduces a new feature that allows users to attend or leave an event directly from the event details screen. The implementation includes backend service integration, repository methods, view model updates, and UI changes to support this functionality.

**Feature: Event Attendance Management**

* Backend integration:
  * Added new API endpoints in `EventService` for checking attendance (`isUserAttending`), attending (`attendEvent`), and removing attendance (`removeAttendance`).
  * Implemented corresponding repository methods in `EventRepository` to interact with these endpoints and expose results as `LiveData`.

* ViewModel enhancements:
  * Added new methods to `EventDetailsViewModel` to provide attendance state and handle attend/leave actions, using the repository and a tracker for one-time observation.

**UI/UX Improvements**

* UI changes:
  * Added an "Attend Event" button to the event details layout (`fragment_event_details.xml`).
  * Initialized and referenced the button in `EventDetailsFragment`, including state variables for attendance. [[1]](diffhunk://#diff-a32e692a92fdf285e5caccea0f69d5a84ba8011bc7564322066910c4daac2b03R60-R62) [[2]](diffhunk://#diff-a32e692a92fdf285e5caccea0f69d5a84ba8011bc7564322066910c4daac2b03R107)

* Interactive logic:
  * Implemented `setupAttendButton` in `EventDetailsFragment` to observe attendance state, update button text, and handle attend/leave actions with feedback via Toast messages. [[1]](diffhunk://#diff-a32e692a92fdf285e5caccea0f69d5a84ba8011bc7564322066910c4daac2b03L113-R118) [[2]](diffhunk://#diff-a32e692a92fdf285e5caccea0f69d5a84ba8011bc7564322066910c4daac2b03R249-R292)